### PR TITLE
fix case where KUUTAMOD_CONSUL_TOKEN_FILE contains newline

### DIFF
--- a/src/bin/kuutamoctl.rs
+++ b/src/bin/kuutamoctl.rs
@@ -40,10 +40,11 @@ const ACCOUNT_ID: &str = "KUUTAMO_ACCOUNT_ID";
 
 async fn show_active_validator(args: &Args) -> Result<i32> {
     let token = match args.consul_token_file {
-        Some(ref file) => Some(
-            fs::read_to_string(&file)
-                .with_context(|| format!("cannot read consul token file {}", file.display()))?,
-        ),
+        Some(ref file) => {
+            let s = fs::read_to_string(&file)
+                .with_context(|| format!("cannot read consul token file {}", file.display()))?;
+            Some(s.trim_end().to_string())
+        }
         None => None,
     };
     let client = ConsulClient::new(&args.consul_url, token.as_deref())

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -124,10 +124,11 @@ pub fn parse_settings() -> Result<Settings> {
     )?;
 
     settings.consul_token = match settings.consul_token_file {
-        Some(ref file) => Some(
-            fs::read_to_string(&file)
-                .with_context(|| format!("cannot read consul token file {}", file.display()))?,
-        ),
+        Some(ref file) => {
+            let s = fs::read_to_string(&file)
+                .with_context(|| format!("cannot read consul token file {}", file.display()))?;
+            Some(s.trim_end().to_string())
+        }
         None => None,
     };
 

--- a/tests/test_single_node.py
+++ b/tests/test_single_node.py
@@ -40,6 +40,8 @@ def test_single_node(
     consul_token = consul_with_acls.management_token
     assert consul_token is not None
     temporary_file.write(consul_token)
+    # Check if kuutamod handles trailing newline gracefully
+    temporary_file.write("\n")
     temporary_file.flush()
 
     env = dict(


### PR DESCRIPTION
This is easy to add by a user and we should ignore it since its not a
valid http header value.